### PR TITLE
Add light sensor event that only fires when valid reading is available.

### DIFF
--- a/inc/core/MicroBitComponent.h
+++ b/inc/core/MicroBitComponent.h
@@ -35,6 +35,7 @@ DEALINGS IN THE SOFTWARE.
 #define MICROBIT_ID_ACCELEROMETER       4
 #define MICROBIT_ID_COMPASS             5
 #define MICROBIT_ID_DISPLAY             6
+#define MICROBIT_ID_LIGHT_SENSOR        7
 
 //EDGE connector events
 #define MICROBIT_IO_PINS                20

--- a/inc/drivers/MicroBitDisplay.h
+++ b/inc/drivers/MicroBitDisplay.h
@@ -627,13 +627,17 @@ public:
       * This also changes the tickPeriod to MICROBIT_LIGHT_SENSOR_TICK_SPEED so
       * that the display does not suffer from artifacts.
       *
+      * @param valid_only True to return -1 if full set of results not taken and to return a stale
+      *            but valid reading in the case of invalid results. False to use all results.
+      *            Defaults to microbitMatrixMap, defined in MicroBitMatrixMaps.h.
+      *
       * @return an indicative light level in the range 0 - 255.
       *
       * @note this will return 0 on the first call to this method, a light reading
       * will be available after the display has activated the light sensor for the
       * first time.
       */
-    int readLightLevel();
+    int readLightLevel(bool valid_only = false);
 
     /**
       * Destructor for MicroBitDisplay, where we deregister this instance from the array of system components.

--- a/inc/drivers/MicroBitLightSensor.h
+++ b/inc/drivers/MicroBitLightSensor.h
@@ -32,12 +32,17 @@ DEALINGS IN THE SOFTWARE.
 #include "EventModel.h"
 #include "MicroBitMatrixMaps.h"
 
-#define MICROBIT_LIGHT_SENSOR_CHAN_NUM      3
-#define MICROBIT_LIGHT_SENSOR_AN_SET_TIME   4000
-#define MICROBIT_LIGHT_SENSOR_TICK_PERIOD   5
+/**
+  * Event codes raised by MicroBitDisplay
+  */
+#define MICROBIT_DISPLAY_EVT_LIGHT_SENSE_READY   1
 
-#define MICROBIT_LIGHT_SENSOR_MAX_VALUE     338
-#define MICROBIT_LIGHT_SENSOR_MIN_VALUE     75
+#define MICROBIT_LIGHT_SENSOR_CHAN_NUM           3
+#define MICROBIT_LIGHT_SENSOR_AN_SET_TIME        4000
+#define MICROBIT_LIGHT_SENSOR_TICK_PERIOD        5
+
+#define MICROBIT_LIGHT_SENSOR_MAX_VALUE          338
+#define MICROBIT_LIGHT_SENSOR_MIN_VALUE          75
 
 /**
   * Class definition for MicroBitLightSensor.
@@ -49,6 +54,12 @@ class MicroBitLightSensor
 
     //contains the results from each section of the display
     int results[MICROBIT_LIGHT_SENSOR_CHAN_NUM];
+
+    // The average of the three results.
+    int average;
+
+    // The average of the three results the last time all results were valid.
+    int valid_average;
 
     //holds the current channel (also used to index the results array)
     uint8_t chan;
@@ -81,6 +92,15 @@ class MicroBitLightSensor
       */
     void analogDisable();
 
+    /**
+      * This method updates the average of the three results, as well as the valid_average
+      * if results are valid. The MICROBIT_DISPLAY_EVT_LIGHT_SENSE_READY event is sent if
+      * the valid_average is updated.
+      *
+      * @return returns a boolean representing whether or not the results are valid.
+      */
+    bool update_averages();
+
     public:
 
     /**
@@ -111,10 +131,14 @@ class MicroBitLightSensor
       *
       * Where each number represents a different section on the 5 x 5 matrix display.
       *
+      * @param valid_only True to return -1 if full set of results not taken and to return a stale
+      *            but valid reading in the case of invalid results. False to use all results.
+      *            Defaults to microbitMatrixMap, defined in MicroBitMatrixMaps.h.
+      *
       * @return returns a value in the range 0 - 255 where 0 is dark, and 255
       * is very bright
       */
-    int read();
+    int read(bool valid_only = false);
 
     /**
       * The method that is invoked by sending MICROBIT_DISPLAY_EVT_LIGHT_SENSE

--- a/source/drivers/MicroBitDisplay.cpp
+++ b/source/drivers/MicroBitDisplay.cpp
@@ -1210,13 +1210,17 @@ MicroBitImage MicroBitDisplay::screenShot()
   * This also changes the tickPeriod to MICROBIT_LIGHT_SENSOR_TICK_SPEED so
   * that the display does not suffer from artifacts.
   *
+  * @param valid_only True to return -1 if full set of results not taken and to return a stale
+  *            but valid reading in the case of invalid results. False to use all results.
+  *            Defaults to microbitMatrixMap, defined in MicroBitMatrixMaps.h.
+  *
   * @return an indicative light level in the range 0 - 255.
   *
-  * @note this will return 0 on the first call to this method, a light reading
-  * will be available after the display has activated the light sensor for the
-  * first time.
+  * @note this will return 255 (previously said 0, which was incorrect)
+  * on the first call to this method, a light reading will be available
+  * after the display has activated the light sensor for the first time.
   */
-int MicroBitDisplay::readLightLevel()
+int MicroBitDisplay::readLightLevel(bool valid_only)
 {
     if(mode != DISPLAY_MODE_BLACK_AND_WHITE_LIGHT_SENSE)
     {
@@ -1224,7 +1228,7 @@ int MicroBitDisplay::readLightLevel()
         this->lightSensor = new MicroBitLightSensor(matrixMap);
     }
 
-    return this->lightSensor->read();
+    return this->lightSensor->read(valid_only);
 }
 
 /**


### PR DESCRIPTION
New event `MICROBIT_DISPLAY_EVT_LIGHT_SENSE_READY` is introduced to resolve two issues.
- Invalid results in first 3/4 readings.
- Invalid results when using bluetooth.
- Invalid results when touching the pins.

This allows for four different behaviours depending on how you interact with the light sensor as shown in the code sample below.

```
#include "MicroBit.h"

MicroBit uBit;
int lightLevel;

bool valid_only = false;
bool use_new_event = false;

void lightLevelReady(MicroBitEvent) {
  lightLevel = uBit.display.readLightLevel(valid_only);
  uBit.serial.send(lightLevel);
  uBit.serial.send("\r\n");
}

int main() {
  uBit.init();
  if (use_new_event) {
      uBit.messageBus.listen(MICROBIT_ID_LIGHT_SENSOR, MICROBIT_DISPLAY_EVT_LIGHT_SENSE_READY, lightLevelReady);
  }
  else {
      uBit.messageBus.listen(MICROBIT_ID_DISPLAY, MICROBIT_DISPLAY_EVT_LIGHT_SENSE, lightLevelReady);
    }
  uBit.display.readLightLevel();
  while (1) {
    fiber_sleep(20);
  }
}
```

- Using the old event and passing either nothing or `false` to `readLightLevel` gives the same behaviour as before, simply returning the values (including invalid ones) every time a reading is taken.
- Using the old event and passing `true` to 'readLightLevel' causes an error value of `-1` to be returned for the first few readings, and stale but valid readings to be returned whenever invalid results are produced.
- Using the new event means that `readLightLevel` is only called when a valid reading is available.
  - Passing `true` to `readLightLevel` when using the new event means that even if a bad result is produced between the event firing and the call to `readLightLevel`, a valid reading will still be returned (either the reading taken when the event was fired, or a more recent valid reading).